### PR TITLE
avoid relying on implicit promotion of const fn calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ macro_rules! raw_one_const {
 	[$type:ty: $a: expr] => {$a};
 	
 	[str: $a: expr, $b: expr] => {{
-		unsafe {
+		const _HIDDEN: &str = unsafe {
 			$crate::ignore_feature::const_raw_ptr(
 				&$crate::raw_one_const!{
 					u8:
@@ -248,7 +248,8 @@ macro_rules! raw_one_const {
 						$b.as_bytes()
 				}
 			)
-		}
+		};
+		_HIDDEN
 	}};
 	
 	[str: $a: expr, $($b: expr),*] => {{
@@ -257,7 +258,7 @@ macro_rules! raw_one_const {
 	
 	[$type:ty: $a: expr, $b: expr] => {{
 		#[allow(unused_unsafe)]
-		unsafe {
+		const _HIDDEN: [$type; $a.len() + $b.len()] = unsafe {
 			$crate::const_concat::<
 				[$type; $a.len()], 
 				[$type; $b.len()],
@@ -265,7 +266,8 @@ macro_rules! raw_one_const {
 				
 				[$type; $a.len() + $b.len()],
 			>($a, $b)
-		}
+		};
+		_HIDDEN
 	}};
 	
 	[$type:ty: $a: expr, $($b: expr),*] => {{


### PR DESCRIPTION
There are plans to [change the rules for implicit promotion](https://github.com/rust-lang/rfcs/pull/3027) such that calls to `const fn` are not implicitly promoted to `'static` lifetime any more. A [crater experiment](https://github.com/rust-lang/rust/pull/80243) showed that only very few crates would be affected by this change, and this is one of them.

This PR adjusts the code to no longer rely on implicit promotion, by explicitly putting the result of the function call into a `const` item. Long-term, there will be the possibility of using [inline const expressions](https://github.com/rust-lang/rust/issues/76001) instead, which will be more ergonomic.