### PR TITLE
2.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cluConstData"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Denis Kotlyarov (Денис Котляров) <denis2005991@gmail.com>"]
 repository = "https://github.com/clucompany/cluConstData.git"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ const_data = []
 clufulltransmute = ["cluFullTransmute"]
 
 [dependencies]
-cluFullTransmute = {version = "1.3.1", default-features = false, features = ["require_debug_assert_transmute", "support_size_check_transmute"], optional = true}
+cluFullTransmute = {version = "1.4.1", default-features = false, features = ["assert_transmute_mode"], optional = true}

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -102,7 +102,7 @@ impl<const CAP: usize, TData: ConstByteBufData> ConstByteBuf<CAP, TData> {
 
 		// TODO WAIT https://github.com/rust-lang/rust/issues/96097 in stable
 		(len, unsafe {
-			cluFullTransmute::unchecked_transmute(self.buf as [MaybeUninit<u8>; CAP])
+			cluFullTransmute::transmute_unchecked(self.buf as [MaybeUninit<u8>; CAP])
 		})
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ where
 	#[cfg_attr(docsrs, doc(cfg(feature = "clufulltransmute")))]
 	#[cfg(feature = "clufulltransmute")]
 	{
-		use cluFullTransmute::unchecked_transmute;
+		use cluFullTransmute::transmute_unchecked;
 		use core::mem::MaybeUninit;
 		let mut result: [MaybeUninit<T>; R_LEN] = [MaybeUninit::uninit(); R_LEN];
 
@@ -135,7 +135,7 @@ where
 		}
 
 		// TODO WAIT https://github.com/rust-lang/rust/issues/96097 in stable
-		unsafe { unchecked_transmute(result) }
+		unsafe { transmute_unchecked(result) }
 	}
 	#[cfg_attr(docsrs, doc(cfg(not(feature = "clufulltransmute"))))]
 	#[cfg(not(feature = "clufulltransmute"))]


### PR DESCRIPTION
2.1.2
================
- fix: version of the `cluFullTransmute` library has been raised to `1.4.1` to resolve build conflicts with non-standard configurations
- build: increase library version to `2.1.2`
